### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WellSwipe\Well划划
-##猎豹"快切App"中用到的Android开发技巧探索[附源码]
-##原文链接：http://blog.csdn.net/u013045971/article/details/52119117
+## 猎豹"快切App"中用到的Android开发技巧探索[附源码]
+## 原文链接：http://blog.csdn.net/u013045971/article/details/52119117
 gif预览：
 
 ![Image text](https://github.com/gumingwei/WellSwipe/blob/master/app/wellswipe4.gif)
@@ -8,19 +8,19 @@ gif预览：
 ![Image text](https://github.com/gumingwei/WellSwipe/blob/master/app/wellswipe5.gif)
 
 
-##支持开发者
-###1.可以这样->进入酷安或者Play下载安装，送上5星好评。
-####酷安：http://www.coolapk.com/apk/com.well.swipe
-####Play：https://play.google.com/store/apps/details?id=com.well.swipe&hl=zh
-###2.也可以这样->如果你觉该项目还不错的话，抬起你的小手，右上角点“star”让我看到你有多帅。
+## 支持开发者
+### 1.可以这样->进入酷安或者Play下载安装，送上5星好评。
+#### 酷安：http://www.coolapk.com/apk/com.well.swipe
+#### Play：https://play.google.com/store/apps/details?id=com.well.swipe&hl=zh
+### 2.也可以这样->如果你觉该项目还不错的话，抬起你的小手，右上角点“star”让我看到你有多帅。
 
-##关于我：
+## 关于我：
 * 微博：     明伟小学生(http://weibo.com/u/2382477985)
 * Github:   https://github.com/gumingwei
 * CSDN:     http://blog.csdn.net/u013045971
 * QQ&WX：   721881283
 
-##中文声明：
+## 中文声明：
 ```
 本项目已经在各大应用商店上线，开源仅供学习交流，作者保留作品的所有权利，严禁用于商业用途，也不要打包到处上传。谢谢合作！
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
